### PR TITLE
Added bank billet payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ yapay.addProduct({
 })
 ```
 
-#### Enviar Transação
+#### Enviar Transação de Cartão
 ```javascript
 yapay.payment({
     card_number: String,
@@ -98,6 +98,15 @@ yapay.payment({
     card_expire_year: String,
     card_cvv: String,
     split: Number
+}, (err, result) => {
+
+})
+```
+
+#### Enviar Transação de Boleto
+```javascript
+yapay.payment({
+    payment_method_id: '6'
 }, (err, result) => {
 
 })

--- a/src/yapay.js
+++ b/src/yapay.js
@@ -405,7 +405,7 @@ yapay.prototype.payment = function(params, cb) {
     }
 
     this.transactionData.payment = {
-        payment_method_id: getPaymentMethodId(params.card_number),
+        payment_method_id: params.payment_method_id || getPaymentMethodId(params.card_number),
         card_number: params.card_number,
         card_name: params.card_name,
         card_expdate_month: params.card_expire_month,


### PR DESCRIPTION
Alterado para que caso for passado o parametro payment_method_id seja usado o passado, e caso não passe continue gerando de acordo com a bandeira do cartão.
Desta forma e possível processar pagamentos em cartão e em boleto.

Exemplo transação em boleto 
```javascript
yapay.payment({  
  payment_method_id: '6'
}, (err, result) => {
})
```